### PR TITLE
登録機能をDBと連携、「呼出」ボタンを「読み込み」ボタンへ変更

### DIFF
--- a/WindowsFormsApp1/Data.cs
+++ b/WindowsFormsApp1/Data.cs
@@ -4,7 +4,7 @@ namespace WindowsFormsApp1
 {
     public class Data
     {
-        public Data(bool completed, string name, String date, string task)
+        public Data(bool completed, string name, DateTime date, string task)
         {
             this.isCompleted = completed;
             this.name = name;
@@ -16,7 +16,7 @@ namespace WindowsFormsApp1
 
         public String name { get; set; }
 
-        public String date { get; set; }
+        public DateTime date { get; set; }
 
         public String task { get; set; }
     }

--- a/WindowsFormsApp1/Form1.Designer.cs
+++ b/WindowsFormsApp1/Form1.Designer.cs
@@ -136,7 +136,7 @@
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(75, 40);
             this.btnImport.TabIndex = 10;
-            this.btnImport.Text = "呼出";
+            this.btnImport.Text = "読み込み";
             this.btnImport.UseVisualStyleBackColor = true;
             this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
             // 

--- a/WindowsFormsApp1/Form1.cs
+++ b/WindowsFormsApp1/Form1.cs
@@ -43,10 +43,11 @@ namespace WindowsFormsApp1
         {
 
             String name = comboBoxName.Text;
-            String date = dateTimePicker.Value.ToShortDateString();
+            DateTime date = dateTimePicker.Value;
             String task = taskTextBox.Text;
 
-            dataGridView.Rows.Add(false, name, date, task);
+            //dataGridView.Rows.Add(false, name, date, task);
+            dao.registerTask(name, date, task);
 
             MessageBox.Show("登録完了");
 
@@ -75,10 +76,7 @@ namespace WindowsFormsApp1
 
         private void btnImport_Click(object sender, EventArgs e)
         {
-            foreach (var data in taskList)
-            {
-                dataGridView.Rows.Add(data.isCompleted, data.name, data.date, data.task);
-            }
+            ToDoList_Load(sender, e);
         }
 
         private void btnHide_Click(object sender, EventArgs e)
@@ -107,7 +105,7 @@ namespace WindowsFormsApp1
                 {
                     Boolean completed = Convert.ToBoolean(row.Cells[0].Value);
                     String name = row.Cells[1].Value.ToString();
-                    String date = Convert.ToDateTime(row.Cells[2].Value).ToShortDateString();
+                    DateTime date = Convert.ToDateTime(row.Cells[2].Value);
                     String task = row.Cells[3].Value.ToString();
 
                     Data data = new Data(completed, name, date, task);

--- a/WindowsFormsApp1/TaskDao.cs
+++ b/WindowsFormsApp1/TaskDao.cs
@@ -30,5 +30,22 @@ namespace WindowsFormsApp1
             return tbl;
         }
 
+        public void registerTask(string name, DateTime date, string task)
+        {
+            string cmdText =
+                "INSERT INTO tasks (name, date, task) VALUES (@name, @date, @task)"; 
+            MySqlConnection conn = new MySqlConnection(connStr);
+            MySqlCommand command = new MySqlCommand(cmdText, conn);
+
+            conn.Open();
+            command.Parameters.AddWithValue("@name", name);
+            command.Parameters.AddWithValue("@date", date);
+            command.Parameters.AddWithValue("@task", task);
+
+            command.ExecuteNonQuery();
+
+            conn.Close();
+        }
+
     }
 }


### PR DESCRIPTION
## 実行前のテーブル
5つのデータが登録されている。
![image](https://github.com/user-attachments/assets/9ac31e30-4ea3-45c3-b53f-4176f33ae7a7)

## 起動時の画面
![image](https://github.com/user-attachments/assets/728f78b3-1322-478c-b1f6-e2b997eae80d)

## タスク詳細を入力し、登録実行
![image](https://github.com/user-attachments/assets/e7b15935-baed-4d00-a732-c4c34033ae93)

## 読み込み実行
みさえ、2024/12/10、クリスマス準備のタスクが表示されている。
![image](https://github.com/user-attachments/assets/b849b60a-de95-4489-8756-188a017aa0ee)

## 実行後のテーブル
1つ増えて、6つのデータが登録されている。
![image](https://github.com/user-attachments/assets/26eb9d92-1a5c-40c1-985e-07280917390f)
