### PR TITLE
保存機能の修正、非表示・全表示機能の修正

### DIFF
--- a/WindowsFormsApp1/Form1.Designer.cs
+++ b/WindowsFormsApp1/Form1.Designer.cs
@@ -196,7 +196,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/WindowsFormsApp1/Form1.cs
+++ b/WindowsFormsApp1/Form1.cs
@@ -1,20 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 
 namespace WindowsFormsApp1
 {
     public partial class ToDoList : Form
     {
+        private TaskDao dao;
+
         public ToDoList(TaskDao dao)
         {
             InitializeComponent();
             this.dao = dao;
         }
-
-        private TaskDao dao;
 
         private void ToDoList_Load(object sender, EventArgs e)
         {
@@ -24,24 +22,28 @@ namespace WindowsFormsApp1
 
             dataGridView.DataSource = dao.loadTasks();
             dataGridView.Columns[0].Name = "ColumnId";
-            dataGridView.Columns[0].Visible = false;
             dataGridView.Columns[1].Name = "ColumnIsCompleted";
-            dataGridView.Columns[1].HeaderText = "完了";
-            dataGridView.Columns[1].Width = 55;
             dataGridView.Columns[2].Name = "ColumnName";
-            dataGridView.Columns[2].HeaderText = "担当";
-            dataGridView.Columns[2].Width = 70;
             dataGridView.Columns[3].Name = "ColumnDate";
-            dataGridView.Columns[3].HeaderText = "日付";
-            dataGridView.Columns[3].Width = 100;
             dataGridView.Columns[4].Name = "ColumnTask";
-            dataGridView.Columns[4].HeaderText = "やること";
-            dataGridView.Columns[4].Width = 200;
+
+            dataGridView.Columns["ColumnId"].Visible = false;
+            dataGridView.Columns["ColumnId"].ReadOnly = true;
+            dataGridView.Columns["ColumnIsCompleted"].HeaderText = "完了";
+            dataGridView.Columns["ColumnIsCompleted"].Width = 55;
+            dataGridView.Columns["ColumnName"].HeaderText = "担当";
+            dataGridView.Columns["ColumnName"].ReadOnly = true;
+            dataGridView.Columns["ColumnName"].Width = 70;
+            dataGridView.Columns["ColumnDate"].HeaderText = "日付";
+            dataGridView.Columns["ColumnDate"].ReadOnly = true;
+            dataGridView.Columns["ColumnDate"].Width = 100;
+            dataGridView.Columns["ColumnTask"].HeaderText = "やること";
+            dataGridView.Columns["ColumnTask"].ReadOnly = true;
+            dataGridView.Columns["ColumnTask"].Width = 200;
         }
 
         private void btnRegister_Click(object sender, EventArgs e)
         {
-
             String name = comboBoxName.Text;
             DateTime date = dateTimePicker.Value;
             String task = taskTextBox.Text;
@@ -79,8 +81,13 @@ namespace WindowsFormsApp1
 
         private void btnSave_Click(object sender, EventArgs e)
         {
-            
+            foreach (DataGridViewRow row in dataGridView.Rows)
+            {
+                Boolean isCompleted = Convert.ToBoolean(row.Cells["ColumnIsCompleted"].Value);
+                int id = Convert.ToInt32(row.Cells["ColumnId"].Value);
 
+                dao.saveTask(isCompleted, id);
+            }
             MessageBox.Show("保存完了");
         }
 
@@ -91,19 +98,24 @@ namespace WindowsFormsApp1
 
         private void btnHide_Click(object sender, EventArgs e)
         {
-            if (dataGridView.DataSource is DataTable dataTable)
+
+            foreach (DataGridViewRow row in dataGridView.Rows)
             {
-                DataView dataView = dataTable.DefaultView;
-                dataView.RowFilter = "is_completed = false";
-                dataGridView.DataSource = dataView;
+                if (row.Cells["ColumnIsCompleted"].Value is true)
+                {
+                    row.Visible = false;
+                }
+                else
+                {
+                }
             }
         }
 
         private void btnUnhide_Click(object sender, EventArgs e)
         {
-            if (dataGridView.DataSource is DataView dataView)
+            foreach (DataGridViewRow row in dataGridView.Rows)
             {
-                dataView.RowFilter = string.Empty;
+                row.Visible = true;
             }
         }
     }

--- a/WindowsFormsApp1/TaskDao.cs
+++ b/WindowsFormsApp1/TaskDao.cs
@@ -1,10 +1,7 @@
-﻿using System.Text;
-using System;
+﻿using System;
 
 using MySql.Data.MySqlClient;
 using System.Data;
-using Microsoft.Extensions.DependencyInjection;
-using System.Data.SqlClient;
 
 namespace WindowsFormsApp1
 {
@@ -61,6 +58,18 @@ namespace WindowsFormsApp1
             conn.Close();
         }
 
+        public void saveTask(Boolean isCompleted, int id)
+        {
+            string cmdText = "UPDATE tasks SET is_completed=@isCompleted WHERE id=@id";
+            MySqlConnection conn = new MySqlConnection(connStr);
+            MySqlCommand command = new MySqlCommand(cmdText, conn);
 
+            conn.Open();
+            command.Parameters.AddWithValue("@id", id);
+            command.Parameters.AddWithValue("@isCompleted", isCompleted);
+            command.ExecuteNonQuery();
+
+            conn.Close();
+        }
     }
 }


### PR DESCRIPTION
# 保存ボタンの機能を修正
完了状態を更新できるよう修正。担当、日付、ToDoは編集不可能。

## 実行前テーブル
全てのタスクが未完了状態
![image](https://github.com/user-attachments/assets/187c27f5-d590-40a3-8727-1537b15294c1)

## 起動時
![image](https://github.com/user-attachments/assets/ad1a0069-ef1e-41f6-b6df-8aee29d928d2)

## 2つだけチェックボックスを入れて保存実行
![image](https://github.com/user-attachments/assets/f10ec315-b8fd-4f12-ba44-ad416e899bd6)

## 実行後テーブル
ID1とID2だけが完了状態
![image](https://github.com/user-attachments/assets/b189ad46-8914-488e-9327-96459aa1134d)


# 非表示・全表示機能を修正
非表示→全表示→非表示のように繰り返すと正常に動作しなかったため、何度でも繰り返せるよう修正。

## 起動時
![image](https://github.com/user-attachments/assets/de17ab4b-7d37-4b7b-8f54-b5228b9e64fe)

## 非表示実行
![image](https://github.com/user-attachments/assets/66044a11-1437-492f-b321-fc80b58010d7)

## その後全表示実行
![image](https://github.com/user-attachments/assets/434175a7-8210-4524-91f3-cb53ad557547)

## 再び非表示実行
![image](https://github.com/user-attachments/assets/b894e9e0-8b4c-42a2-b754-fa9941e762c0)

## 再び全表示実行
![image](https://github.com/user-attachments/assets/2a1dab19-9625-4001-ad9f-06c17a4123bf)
